### PR TITLE
Upgrade terraform-provider-grafana to v4.12.2

### DIFF
--- a/.config/mise.lock
+++ b/.config/mise.lock
@@ -11,18 +11,13 @@ version = "0.6.0"
 backend = "github:pulumi/schema-tools"
 
 [[tools.go]]
-version = "1.25.3"
+version = "1.25.4"
 backend = "core:go"
 
 [tools.go.platforms.linux-x64]
-checksum = "sha256:0335f314b6e7bfe08c3d0cfaa7c19db961b7b99fb20be62b0a826c992ad14e0f"
-size = 59767979
-url = "https://dl.google.com/go/go1.25.3.linux-amd64.tar.gz"
-
-[tools.go.platforms.macos-arm64]
-checksum = "sha256:7c083e3d2c00debfeb2f77d9a4c00a1aac97113b89b9ccc42a90487af3437382"
-size = 58028114
-url = "https://dl.google.com/go/go1.25.3.darwin-arm64.tar.gz"
+checksum = "sha256:9fa5ffeda4170de60f67f3aa0f824e426421ba724c21e133c1e35d6159ca1bec"
+size = 59766394
+url = "https://dl.google.com/go/go1.25.4.linux-amd64.tar.gz"
 
 [[tools.gradle]]
 version = "7.6.6"
@@ -69,7 +64,7 @@ version = "3.11.8"
 backend = "core:python"
 
 [[tools."vfox-pulumi:pulumi/pulumi-aws"]]
-version = "7.10.0"
+version = "7.11.0"
 backend = "vfox-pulumi:pulumi/pulumi-aws"
 
 [[tools."vfox-pulumi:pulumi/pulumi-converter-terraform"]]

--- a/provider/cmd/pulumi-resource-grafana/schema.json
+++ b/provider/cmd/pulumi-resource-grafana/schema.json
@@ -13889,6 +13889,14 @@
                     "type": "string",
                     "description": "The ID of a Team for a notify*team*members type step.\n"
                 },
+                "numAlertsInWindow": {
+                    "type": "integer",
+                    "description": "Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.\n"
+                },
+                "numMinutesInWindow": {
+                    "type": "integer",
+                    "description": "Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.\n"
+                },
                 "personsToNotifies": {
                     "type": "array",
                     "items": {
@@ -13913,7 +13921,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident\n"
+                    "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident\n"
                 }
             },
             "required": [
@@ -13959,6 +13967,14 @@
                     "type": "string",
                     "description": "The ID of a Team for a notify*team*members type step.\n"
                 },
+                "numAlertsInWindow": {
+                    "type": "integer",
+                    "description": "Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.\n"
+                },
+                "numMinutesInWindow": {
+                    "type": "integer",
+                    "description": "Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.\n"
+                },
                 "personsToNotifies": {
                     "type": "array",
                     "items": {
@@ -13983,7 +13999,7 @@
                 },
                 "type": {
                     "type": "string",
-                    "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident\n"
+                    "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident\n"
                 }
             },
             "requiredInputs": [
@@ -14031,6 +14047,14 @@
                         "type": "string",
                         "description": "The ID of a Team for a notify*team*members type step.\n"
                     },
+                    "numAlertsInWindow": {
+                        "type": "integer",
+                        "description": "Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.\n"
+                    },
+                    "numMinutesInWindow": {
+                        "type": "integer",
+                        "description": "Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.\n"
+                    },
                     "personsToNotifies": {
                         "type": "array",
                         "items": {
@@ -14055,7 +14079,7 @@
                     },
                     "type": {
                         "type": "string",
-                        "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident\n"
+                        "description": "The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident\n"
                     }
                 },
                 "type": "object"
@@ -19348,7 +19372,7 @@
             }
         },
         "grafana:k6/getProjectLimits:getProjectLimits": {
-            "description": "Retrieves a k6 project limits.\n\n## Example Usage\n\n\u003c!--Start PulumiCodeChooser --\u003e\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as grafana from \"@pulumiverse/grafana\";\n\nconst testProjectLimits = new grafana.k6.Project(\"test_project_limits\", {name: \"Terraform Project Test Limits\"});\nconst fromProjectId = grafana.k6.getProjectLimitsOutput({\n    projectId: testProjectLimits.id,\n});\n```\n```python\nimport pulumi\nimport pulumi_grafana as grafana\nimport pulumiverse_grafana as grafana\n\ntest_project_limits = grafana.k6.Project(\"test_project_limits\", name=\"Terraform Project Test Limits\")\nfrom_project_id = grafana.k6.get_project_limits_output(project_id=test_project_limits.id)\n```\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing Pulumi;\nusing Grafana = Pulumi.Grafana;\nusing Grafana = Pulumiverse.Grafana;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var testProjectLimits = new Grafana.K6.Project(\"test_project_limits\", new()\n    {\n        Name = \"Terraform Project Test Limits\",\n    });\n\n    var fromProjectId = Grafana.K6.GetProjectLimits.Invoke(new()\n    {\n        ProjectId = testProjectLimits.Id,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n\t\"github.com/pulumiverse/pulumi-grafana/sdk/v2/go/grafana/k6\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestProjectLimits, err := k6.NewProject(ctx, \"test_project_limits\", \u0026k6.ProjectArgs{\n\t\t\tName: pulumi.String(\"Terraform Project Test Limits\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_ = k6.LookupProjectLimitsOutput(ctx, k6.GetProjectLimitsOutputArgs{\n\t\t\tProjectId: testProjectLimits.ID(),\n\t\t}, nil)\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.grafana.k6.Project;\nimport com.pulumi.grafana.k6.ProjectArgs;\nimport com.pulumi.grafana.k6.K6Functions;\nimport com.pulumi.grafana.k6.inputs.GetProjectLimitsArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var testProjectLimits = new Project(\"testProjectLimits\", ProjectArgs.builder()\n            .name(\"Terraform Project Test Limits\")\n            .build());\n\n        final var fromProjectId = K6Functions.getProjectLimits(GetProjectLimitsArgs.builder()\n            .projectId(testProjectLimits.id())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  testProjectLimits:\n    type: grafana:k6:Project\n    name: test_project_limits\n    properties:\n      name: Terraform Project Test Limits\nvariables:\n  fromProjectId:\n    fn::invoke:\n      function: grafana:k6:getProjectLimits\n      arguments:\n        projectId: ${testProjectLimits.id}\n```\n\u003c!--End PulumiCodeChooser --\u003e\n",
+            "description": "Retrieves a k6 project limits.\n\n## Example Usage\n\n\u003c!--Start PulumiCodeChooser --\u003e\n```typescript\nimport * as pulumi from \"@pulumi/pulumi\";\nimport * as grafana from \"@pulumiverse/grafana\";\n\nconst testProjectLimits = new grafana.k6.Project(\"test_project_limits\", {name: \"Terraform Project Test Limits\"});\nconst testLimits = new grafana.k6.ProjectLimits(\"test_limits\", {\n    projectId: testProjectLimits.id,\n    vuhMaxPerMonth: 10000,\n    vuMaxPerTest: 10000,\n    vuBrowserMaxPerTest: 1000,\n    durationMaxPerTest: 3600,\n});\nconst fromProjectId = grafana.k6.getProjectLimitsOutput({\n    projectId: testProjectLimits.id,\n});\n```\n```python\nimport pulumi\nimport pulumi_grafana as grafana\nimport pulumiverse_grafana as grafana\n\ntest_project_limits = grafana.k6.Project(\"test_project_limits\", name=\"Terraform Project Test Limits\")\ntest_limits = grafana.k6.ProjectLimits(\"test_limits\",\n    project_id=test_project_limits.id,\n    vuh_max_per_month=10000,\n    vu_max_per_test=10000,\n    vu_browser_max_per_test=1000,\n    duration_max_per_test=3600)\nfrom_project_id = grafana.k6.get_project_limits_output(project_id=test_project_limits.id)\n```\n```csharp\nusing System.Collections.Generic;\nusing System.Linq;\nusing Pulumi;\nusing Grafana = Pulumi.Grafana;\nusing Grafana = Pulumiverse.Grafana;\n\nreturn await Deployment.RunAsync(() =\u003e \n{\n    var testProjectLimits = new Grafana.K6.Project(\"test_project_limits\", new()\n    {\n        Name = \"Terraform Project Test Limits\",\n    });\n\n    var testLimits = new Grafana.K6.ProjectLimits(\"test_limits\", new()\n    {\n        ProjectId = testProjectLimits.Id,\n        VuhMaxPerMonth = 10000,\n        VuMaxPerTest = 10000,\n        VuBrowserMaxPerTest = 1000,\n        DurationMaxPerTest = 3600,\n    });\n\n    var fromProjectId = Grafana.K6.GetProjectLimits.Invoke(new()\n    {\n        ProjectId = testProjectLimits.Id,\n    });\n\n});\n```\n```go\npackage main\n\nimport (\n\t\"github.com/pulumi/pulumi/sdk/v3/go/pulumi\"\n\t\"github.com/pulumiverse/pulumi-grafana/sdk/v2/go/grafana/k6\"\n)\n\nfunc main() {\n\tpulumi.Run(func(ctx *pulumi.Context) error {\n\t\ttestProjectLimits, err := k6.NewProject(ctx, \"test_project_limits\", \u0026k6.ProjectArgs{\n\t\t\tName: pulumi.String(\"Terraform Project Test Limits\"),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_, err = k6.NewProjectLimits(ctx, \"test_limits\", \u0026k6.ProjectLimitsArgs{\n\t\t\tProjectId:           testProjectLimits.ID(),\n\t\t\tVuhMaxPerMonth:      pulumi.Int(10000),\n\t\t\tVuMaxPerTest:        pulumi.Int(10000),\n\t\t\tVuBrowserMaxPerTest: pulumi.Int(1000),\n\t\t\tDurationMaxPerTest:  pulumi.Int(3600),\n\t\t})\n\t\tif err != nil {\n\t\t\treturn err\n\t\t}\n\t\t_ = k6.LookupProjectLimitsOutput(ctx, k6.GetProjectLimitsOutputArgs{\n\t\t\tProjectId: testProjectLimits.ID(),\n\t\t}, nil)\n\t\treturn nil\n\t})\n}\n```\n```java\npackage generated_program;\n\nimport com.pulumi.Context;\nimport com.pulumi.Pulumi;\nimport com.pulumi.core.Output;\nimport com.pulumi.grafana.k6.Project;\nimport com.pulumi.grafana.k6.ProjectArgs;\nimport com.pulumi.grafana.k6.ProjectLimits;\nimport com.pulumi.grafana.k6.ProjectLimitsArgs;\nimport com.pulumi.grafana.k6.K6Functions;\nimport com.pulumi.grafana.k6.inputs.GetProjectLimitsArgs;\nimport java.util.List;\nimport java.util.ArrayList;\nimport java.util.Map;\nimport java.io.File;\nimport java.nio.file.Files;\nimport java.nio.file.Paths;\n\npublic class App {\n    public static void main(String[] args) {\n        Pulumi.run(App::stack);\n    }\n\n    public static void stack(Context ctx) {\n        var testProjectLimits = new Project(\"testProjectLimits\", ProjectArgs.builder()\n            .name(\"Terraform Project Test Limits\")\n            .build());\n\n        var testLimits = new ProjectLimits(\"testLimits\", ProjectLimitsArgs.builder()\n            .projectId(testProjectLimits.id())\n            .vuhMaxPerMonth(10000)\n            .vuMaxPerTest(10000)\n            .vuBrowserMaxPerTest(1000)\n            .durationMaxPerTest(3600)\n            .build());\n\n        final var fromProjectId = K6Functions.getProjectLimits(GetProjectLimitsArgs.builder()\n            .projectId(testProjectLimits.id())\n            .build());\n\n    }\n}\n```\n```yaml\nresources:\n  testProjectLimits:\n    type: grafana:k6:Project\n    name: test_project_limits\n    properties:\n      name: Terraform Project Test Limits\n  testLimits:\n    type: grafana:k6:ProjectLimits\n    name: test_limits\n    properties:\n      projectId: ${testProjectLimits.id}\n      vuhMaxPerMonth: 10000\n      vuMaxPerTest: 10000\n      vuBrowserMaxPerTest: 1000\n      durationMaxPerTest: 3600\nvariables:\n  fromProjectId:\n    fn::invoke:\n      function: grafana:k6:getProjectLimits\n      arguments:\n        projectId: ${testProjectLimits.id}\n```\n\u003c!--End PulumiCodeChooser --\u003e\n",
             "inputs": {
                 "description": "A collection of arguments for invoking getProjectLimits.\n",
                 "properties": {

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.25
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250530111747-935112552988
 
 require (
-	github.com/grafana/terraform-provider-grafana/v4 v4.12.1
+	github.com/grafana/terraform-provider-grafana/v4 v4.12.2
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.114.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
 )
@@ -107,7 +107,7 @@ require (
 	github.com/googleapis/enterprise-certificate-proxy v0.3.4 // indirect
 	github.com/googleapis/gax-go/v2 v2.14.1 // indirect
 	github.com/gorilla/mux v1.8.1 // indirect
-	github.com/grafana/amixr-api-go-client v0.0.25 // indirect
+	github.com/grafana/amixr-api-go-client v0.0.27 // indirect
 	github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437 // indirect
 	github.com/grafana/fleet-management-api v1.0.0 // indirect
 	github.com/grafana/grafana-app-sdk v0.45.0 // indirect

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -1928,8 +1928,8 @@ github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e h1:JKmoR8x90Iww1
 github.com/gopherjs/gopherjs v0.0.0-20181103185306-d547d1d9531e/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
 github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=
-github.com/grafana/amixr-api-go-client v0.0.25 h1:tAQeJRuq9ihHotxq6/oEB6lIhuAdM+MUP0uPkNn1I3A=
-github.com/grafana/amixr-api-go-client v0.0.25/go.mod h1:ihgLhTVimmjASuZ06y/mQxPcYH3toAIuUVGK6flHsMU=
+github.com/grafana/amixr-api-go-client v0.0.27 h1:tmw7JcbX3D0N52mK60kYvAdRNFKH0aOb+9FKPaye2sc=
+github.com/grafana/amixr-api-go-client v0.0.27/go.mod h1:ihgLhTVimmjASuZ06y/mQxPcYH3toAIuUVGK6flHsMU=
 github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437 h1:OlwbIVFcYgMjnQhpbZwRPVNrvZKTodvPMqwb8yEqVW0=
 github.com/grafana/authlib/claims v0.0.0-20250120084028-e3328c576437/go.mod h1:r+F8H6awwjNQt/KPZ2GNwjk8TvsJ7/gxzkXN26GlL/A=
 github.com/grafana/fleet-management-api v1.0.0 h1:twb0kBgeNRcvQi7iDXq7AFhlM2mWcN76kTXleJuPA38=
@@ -1970,8 +1970,8 @@ github.com/grafana/synthetic-monitoring-agent v0.43.1 h1:Qejsuf25yZzdImVLZ6K1f5c
 github.com/grafana/synthetic-monitoring-agent v0.43.1/go.mod h1:HO4es33UF/5b3i4JdUhVcvs9abUXESMjFxnWP8y6KG0=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 h1:6ZQoQVD0sASxe5OVEk/T/YEOYOuilSA434bX4n3SJLQ=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1/go.mod h1:3XfDhlxYkC/Apaug0e0vd4wHx8JZJ4k+v5ybny8ZGfc=
-github.com/grafana/terraform-provider-grafana/v4 v4.12.1 h1:AKjwR4/F3pSvLERQO/TlfNbNppmbCnNlF8f3Q58crj4=
-github.com/grafana/terraform-provider-grafana/v4 v4.12.1/go.mod h1:V/wDwgFj7tPYBC+0PCnkMMuLaCztG8rSRypg6NCwhQo=
+github.com/grafana/terraform-provider-grafana/v4 v4.12.2 h1:QmtsrGSGLTo2sXbWCWkYulsL/XYQgwrzjHVBsQmPU3Y=
+github.com/grafana/terraform-provider-grafana/v4 v4.12.2/go.mod h1:a/Uk33a4UkY7KKEL+RomJW7N5GlqZSX9sxTlC4f9MP8=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=
 github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.3.2 h1:sGm2vDRFUrQJO/Veii4h4zG2vvqG6uWNkBHSTqXOZk0=

--- a/sdk/dotnet/K6/GetProjectLimits.cs
+++ b/sdk/dotnet/K6/GetProjectLimits.cs
@@ -31,6 +31,15 @@ namespace Pulumiverse.Grafana.K6
         ///         Name = "Terraform Project Test Limits",
         ///     });
         /// 
+        ///     var testLimits = new Grafana.K6.ProjectLimits("test_limits", new()
+        ///     {
+        ///         ProjectId = testProjectLimits.Id,
+        ///         VuhMaxPerMonth = 10000,
+        ///         VuMaxPerTest = 10000,
+        ///         VuBrowserMaxPerTest = 1000,
+        ///         DurationMaxPerTest = 3600,
+        ///     });
+        /// 
         ///     var fromProjectId = Grafana.K6.GetProjectLimits.Invoke(new()
         ///     {
         ///         ProjectId = testProjectLimits.Id,
@@ -61,6 +70,15 @@ namespace Pulumiverse.Grafana.K6
         ///         Name = "Terraform Project Test Limits",
         ///     });
         /// 
+        ///     var testLimits = new Grafana.K6.ProjectLimits("test_limits", new()
+        ///     {
+        ///         ProjectId = testProjectLimits.Id,
+        ///         VuhMaxPerMonth = 10000,
+        ///         VuMaxPerTest = 10000,
+        ///         VuBrowserMaxPerTest = 1000,
+        ///         DurationMaxPerTest = 3600,
+        ///     });
+        /// 
         ///     var fromProjectId = Grafana.K6.GetProjectLimits.Invoke(new()
         ///     {
         ///         ProjectId = testProjectLimits.Id,
@@ -89,6 +107,15 @@ namespace Pulumiverse.Grafana.K6
         ///     var testProjectLimits = new Grafana.K6.Project("test_project_limits", new()
         ///     {
         ///         Name = "Terraform Project Test Limits",
+        ///     });
+        /// 
+        ///     var testLimits = new Grafana.K6.ProjectLimits("test_limits", new()
+        ///     {
+        ///         ProjectId = testProjectLimits.Id,
+        ///         VuhMaxPerMonth = 10000,
+        ///         VuMaxPerTest = 10000,
+        ///         VuBrowserMaxPerTest = 1000,
+        ///         DurationMaxPerTest = 3600,
         ///     });
         /// 
         ///     var fromProjectId = Grafana.K6.GetProjectLimits.Invoke(new()

--- a/sdk/dotnet/OnCall/Escalation.cs
+++ b/sdk/dotnet/OnCall/Escalation.cs
@@ -78,6 +78,18 @@ namespace Pulumiverse.Grafana.OnCall
         public Output<string?> NotifyToTeamMembers { get; private set; } = null!;
 
         /// <summary>
+        /// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Output("numAlertsInWindow")]
+        public Output<int?> NumAlertsInWindow { get; private set; } = null!;
+
+        /// <summary>
+        /// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Output("numMinutesInWindow")]
+        public Output<int?> NumMinutesInWindow { get; private set; } = null!;
+
+        /// <summary>
         /// The list of ID's of users for notify_persons type step.
         /// </summary>
         [Output("personsToNotifies")]
@@ -102,7 +114,7 @@ namespace Pulumiverse.Grafana.OnCall
         public Output<string?> Severity { get; private set; } = null!;
 
         /// <summary>
-        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         /// </summary>
         [Output("type")]
         public Output<string> Type { get; private set; } = null!;
@@ -208,6 +220,18 @@ namespace Pulumiverse.Grafana.OnCall
         [Input("notifyToTeamMembers")]
         public Input<string>? NotifyToTeamMembers { get; set; }
 
+        /// <summary>
+        /// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Input("numAlertsInWindow")]
+        public Input<int>? NumAlertsInWindow { get; set; }
+
+        /// <summary>
+        /// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Input("numMinutesInWindow")]
+        public Input<int>? NumMinutesInWindow { get; set; }
+
         [Input("personsToNotifies")]
         private InputList<string>? _personsToNotifies;
 
@@ -245,7 +269,7 @@ namespace Pulumiverse.Grafana.OnCall
         public Input<string>? Severity { get; set; }
 
         /// <summary>
-        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         /// </summary>
         [Input("type", required: true)]
         public Input<string> Type { get; set; } = null!;
@@ -312,6 +336,18 @@ namespace Pulumiverse.Grafana.OnCall
         [Input("notifyToTeamMembers")]
         public Input<string>? NotifyToTeamMembers { get; set; }
 
+        /// <summary>
+        /// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Input("numAlertsInWindow")]
+        public Input<int>? NumAlertsInWindow { get; set; }
+
+        /// <summary>
+        /// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        /// </summary>
+        [Input("numMinutesInWindow")]
+        public Input<int>? NumMinutesInWindow { get; set; }
+
         [Input("personsToNotifies")]
         private InputList<string>? _personsToNotifies;
 
@@ -349,7 +385,7 @@ namespace Pulumiverse.Grafana.OnCall
         public Input<string>? Severity { get; set; }
 
         /// <summary>
-        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        /// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         /// </summary>
         [Input("type")]
         public Input<string>? Type { get; set; }

--- a/sdk/go/grafana/k6/getProjectLimits.go
+++ b/sdk/go/grafana/k6/getProjectLimits.go
@@ -33,6 +33,16 @@ import (
 //			if err != nil {
 //				return err
 //			}
+//			_, err = k6.NewProjectLimits(ctx, "test_limits", &k6.ProjectLimitsArgs{
+//				ProjectId:           testProjectLimits.ID(),
+//				VuhMaxPerMonth:      pulumi.Int(10000),
+//				VuMaxPerTest:        pulumi.Int(10000),
+//				VuBrowserMaxPerTest: pulumi.Int(1000),
+//				DurationMaxPerTest:  pulumi.Int(3600),
+//			})
+//			if err != nil {
+//				return err
+//			}
 //			_ = k6.LookupProjectLimitsOutput(ctx, k6.GetProjectLimitsOutputArgs{
 //				ProjectId: testProjectLimits.ID(),
 //			}, nil)

--- a/sdk/go/grafana/oncall/escalation.go
+++ b/sdk/go/grafana/oncall/escalation.go
@@ -41,6 +41,10 @@ type Escalation struct {
 	NotifyOnCallFromSchedule pulumi.StringPtrOutput `pulumi:"notifyOnCallFromSchedule"`
 	// The ID of a Team for a notify*team*members type step.
 	NotifyToTeamMembers pulumi.StringPtrOutput `pulumi:"notifyToTeamMembers"`
+	// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+	NumAlertsInWindow pulumi.IntPtrOutput `pulumi:"numAlertsInWindow"`
+	// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+	NumMinutesInWindow pulumi.IntPtrOutput `pulumi:"numMinutesInWindow"`
 	// The list of ID's of users for notifyPersons type step.
 	PersonsToNotifies pulumi.StringArrayOutput `pulumi:"personsToNotifies"`
 	// The list of ID's of users for notify*person*next*each*time type step.
@@ -49,7 +53,7 @@ type Escalation struct {
 	Position pulumi.IntOutput `pulumi:"position"`
 	// The severity of the incident for declareIncident type step.
 	Severity pulumi.StringPtrOutput `pulumi:"severity"`
-	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 	Type pulumi.StringOutput `pulumi:"type"`
 }
 
@@ -110,6 +114,10 @@ type escalationState struct {
 	NotifyOnCallFromSchedule *string `pulumi:"notifyOnCallFromSchedule"`
 	// The ID of a Team for a notify*team*members type step.
 	NotifyToTeamMembers *string `pulumi:"notifyToTeamMembers"`
+	// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+	NumAlertsInWindow *int `pulumi:"numAlertsInWindow"`
+	// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+	NumMinutesInWindow *int `pulumi:"numMinutesInWindow"`
 	// The list of ID's of users for notifyPersons type step.
 	PersonsToNotifies []string `pulumi:"personsToNotifies"`
 	// The list of ID's of users for notify*person*next*each*time type step.
@@ -118,7 +126,7 @@ type escalationState struct {
 	Position *int `pulumi:"position"`
 	// The severity of the incident for declareIncident type step.
 	Severity *string `pulumi:"severity"`
-	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 	Type *string `pulumi:"type"`
 }
 
@@ -141,6 +149,10 @@ type EscalationState struct {
 	NotifyOnCallFromSchedule pulumi.StringPtrInput
 	// The ID of a Team for a notify*team*members type step.
 	NotifyToTeamMembers pulumi.StringPtrInput
+	// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+	NumAlertsInWindow pulumi.IntPtrInput
+	// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+	NumMinutesInWindow pulumi.IntPtrInput
 	// The list of ID's of users for notifyPersons type step.
 	PersonsToNotifies pulumi.StringArrayInput
 	// The list of ID's of users for notify*person*next*each*time type step.
@@ -149,7 +161,7 @@ type EscalationState struct {
 	Position pulumi.IntPtrInput
 	// The severity of the incident for declareIncident type step.
 	Severity pulumi.StringPtrInput
-	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 	Type pulumi.StringPtrInput
 }
 
@@ -176,6 +188,10 @@ type escalationArgs struct {
 	NotifyOnCallFromSchedule *string `pulumi:"notifyOnCallFromSchedule"`
 	// The ID of a Team for a notify*team*members type step.
 	NotifyToTeamMembers *string `pulumi:"notifyToTeamMembers"`
+	// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+	NumAlertsInWindow *int `pulumi:"numAlertsInWindow"`
+	// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+	NumMinutesInWindow *int `pulumi:"numMinutesInWindow"`
 	// The list of ID's of users for notifyPersons type step.
 	PersonsToNotifies []string `pulumi:"personsToNotifies"`
 	// The list of ID's of users for notify*person*next*each*time type step.
@@ -184,7 +200,7 @@ type escalationArgs struct {
 	Position int `pulumi:"position"`
 	// The severity of the incident for declareIncident type step.
 	Severity *string `pulumi:"severity"`
-	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 	Type string `pulumi:"type"`
 }
 
@@ -208,6 +224,10 @@ type EscalationArgs struct {
 	NotifyOnCallFromSchedule pulumi.StringPtrInput
 	// The ID of a Team for a notify*team*members type step.
 	NotifyToTeamMembers pulumi.StringPtrInput
+	// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+	NumAlertsInWindow pulumi.IntPtrInput
+	// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+	NumMinutesInWindow pulumi.IntPtrInput
 	// The list of ID's of users for notifyPersons type step.
 	PersonsToNotifies pulumi.StringArrayInput
 	// The list of ID's of users for notify*person*next*each*time type step.
@@ -216,7 +236,7 @@ type EscalationArgs struct {
 	Position pulumi.IntInput
 	// The severity of the incident for declareIncident type step.
 	Severity pulumi.StringPtrInput
-	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+	// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 	Type pulumi.StringInput
 }
 
@@ -352,6 +372,16 @@ func (o EscalationOutput) NotifyToTeamMembers() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Escalation) pulumi.StringPtrOutput { return v.NotifyToTeamMembers }).(pulumi.StringPtrOutput)
 }
 
+// Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+func (o EscalationOutput) NumAlertsInWindow() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Escalation) pulumi.IntPtrOutput { return v.NumAlertsInWindow }).(pulumi.IntPtrOutput)
+}
+
+// Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+func (o EscalationOutput) NumMinutesInWindow() pulumi.IntPtrOutput {
+	return o.ApplyT(func(v *Escalation) pulumi.IntPtrOutput { return v.NumMinutesInWindow }).(pulumi.IntPtrOutput)
+}
+
 // The list of ID's of users for notifyPersons type step.
 func (o EscalationOutput) PersonsToNotifies() pulumi.StringArrayOutput {
 	return o.ApplyT(func(v *Escalation) pulumi.StringArrayOutput { return v.PersonsToNotifies }).(pulumi.StringArrayOutput)
@@ -372,7 +402,7 @@ func (o EscalationOutput) Severity() pulumi.StringPtrOutput {
 	return o.ApplyT(func(v *Escalation) pulumi.StringPtrOutput { return v.Severity }).(pulumi.StringPtrOutput)
 }
 
-// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+// The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
 func (o EscalationOutput) Type() pulumi.StringOutput {
 	return o.ApplyT(func(v *Escalation) pulumi.StringOutput { return v.Type }).(pulumi.StringOutput)
 }

--- a/sdk/nodejs/k6/getProjectLimits.ts
+++ b/sdk/nodejs/k6/getProjectLimits.ts
@@ -14,6 +14,13 @@ import * as utilities from "../utilities";
  * import * as grafana from "@pulumiverse/grafana";
  *
  * const testProjectLimits = new grafana.k6.Project("test_project_limits", {name: "Terraform Project Test Limits"});
+ * const testLimits = new grafana.k6.ProjectLimits("test_limits", {
+ *     projectId: testProjectLimits.id,
+ *     vuhMaxPerMonth: 10000,
+ *     vuMaxPerTest: 10000,
+ *     vuBrowserMaxPerTest: 1000,
+ *     durationMaxPerTest: 3600,
+ * });
  * const fromProjectId = grafana.k6.getProjectLimitsOutput({
  *     projectId: testProjectLimits.id,
  * });
@@ -75,6 +82,13 @@ export interface GetProjectLimitsResult {
  * import * as grafana from "@pulumiverse/grafana";
  *
  * const testProjectLimits = new grafana.k6.Project("test_project_limits", {name: "Terraform Project Test Limits"});
+ * const testLimits = new grafana.k6.ProjectLimits("test_limits", {
+ *     projectId: testProjectLimits.id,
+ *     vuhMaxPerMonth: 10000,
+ *     vuMaxPerTest: 10000,
+ *     vuBrowserMaxPerTest: 1000,
+ *     durationMaxPerTest: 3600,
+ * });
  * const fromProjectId = grafana.k6.getProjectLimitsOutput({
  *     projectId: testProjectLimits.id,
  * });

--- a/sdk/nodejs/oncall/escalation.ts
+++ b/sdk/nodejs/oncall/escalation.ts
@@ -79,6 +79,14 @@ export class Escalation extends pulumi.CustomResource {
      */
     declare public readonly notifyToTeamMembers: pulumi.Output<string | undefined>;
     /**
+     * Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+     */
+    declare public readonly numAlertsInWindow: pulumi.Output<number | undefined>;
+    /**
+     * Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+     */
+    declare public readonly numMinutesInWindow: pulumi.Output<number | undefined>;
+    /**
      * The list of ID's of users for notifyPersons type step.
      */
     declare public readonly personsToNotifies: pulumi.Output<string[] | undefined>;
@@ -95,7 +103,7 @@ export class Escalation extends pulumi.CustomResource {
      */
     declare public readonly severity: pulumi.Output<string | undefined>;
     /**
-     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
      */
     declare public readonly type: pulumi.Output<string>;
 
@@ -121,6 +129,8 @@ export class Escalation extends pulumi.CustomResource {
             resourceInputs["notifyIfTimeTo"] = state?.notifyIfTimeTo;
             resourceInputs["notifyOnCallFromSchedule"] = state?.notifyOnCallFromSchedule;
             resourceInputs["notifyToTeamMembers"] = state?.notifyToTeamMembers;
+            resourceInputs["numAlertsInWindow"] = state?.numAlertsInWindow;
+            resourceInputs["numMinutesInWindow"] = state?.numMinutesInWindow;
             resourceInputs["personsToNotifies"] = state?.personsToNotifies;
             resourceInputs["personsToNotifyNextEachTimes"] = state?.personsToNotifyNextEachTimes;
             resourceInputs["position"] = state?.position;
@@ -146,6 +156,8 @@ export class Escalation extends pulumi.CustomResource {
             resourceInputs["notifyIfTimeTo"] = args?.notifyIfTimeTo;
             resourceInputs["notifyOnCallFromSchedule"] = args?.notifyOnCallFromSchedule;
             resourceInputs["notifyToTeamMembers"] = args?.notifyToTeamMembers;
+            resourceInputs["numAlertsInWindow"] = args?.numAlertsInWindow;
+            resourceInputs["numMinutesInWindow"] = args?.numMinutesInWindow;
             resourceInputs["personsToNotifies"] = args?.personsToNotifies;
             resourceInputs["personsToNotifyNextEachTimes"] = args?.personsToNotifyNextEachTimes;
             resourceInputs["position"] = args?.position;
@@ -198,6 +210,14 @@ export interface EscalationState {
      */
     notifyToTeamMembers?: pulumi.Input<string>;
     /**
+     * Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+     */
+    numAlertsInWindow?: pulumi.Input<number>;
+    /**
+     * Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+     */
+    numMinutesInWindow?: pulumi.Input<number>;
+    /**
      * The list of ID's of users for notifyPersons type step.
      */
     personsToNotifies?: pulumi.Input<pulumi.Input<string>[]>;
@@ -214,7 +234,7 @@ export interface EscalationState {
      */
     severity?: pulumi.Input<string>;
     /**
-     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
      */
     type?: pulumi.Input<string>;
 }
@@ -260,6 +280,14 @@ export interface EscalationArgs {
      */
     notifyToTeamMembers?: pulumi.Input<string>;
     /**
+     * Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+     */
+    numAlertsInWindow?: pulumi.Input<number>;
+    /**
+     * Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+     */
+    numMinutesInWindow?: pulumi.Input<number>;
+    /**
      * The list of ID's of users for notifyPersons type step.
      */
     personsToNotifies?: pulumi.Input<pulumi.Input<string>[]>;
@@ -276,7 +304,7 @@ export interface EscalationArgs {
      */
     severity?: pulumi.Input<string>;
     /**
-     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+     * The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
      */
     type: pulumi.Input<string>;
 }

--- a/sdk/python/pulumiverse_grafana/k6/get_project_limits.py
+++ b/sdk/python/pulumiverse_grafana/k6/get_project_limits.py
@@ -122,6 +122,12 @@ def get_project_limits(project_id: Optional[_builtins.str] = None,
     import pulumiverse_grafana as grafana
 
     test_project_limits = grafana.k6.Project("test_project_limits", name="Terraform Project Test Limits")
+    test_limits = grafana.k6.ProjectLimits("test_limits",
+        project_id=test_project_limits.id,
+        vuh_max_per_month=10000,
+        vu_max_per_test=10000,
+        vu_browser_max_per_test=1000,
+        duration_max_per_test=3600)
     from_project_id = grafana.k6.get_project_limits_output(project_id=test_project_limits.id)
     ```
 
@@ -153,6 +159,12 @@ def get_project_limits_output(project_id: Optional[pulumi.Input[_builtins.str]] 
     import pulumiverse_grafana as grafana
 
     test_project_limits = grafana.k6.Project("test_project_limits", name="Terraform Project Test Limits")
+    test_limits = grafana.k6.ProjectLimits("test_limits",
+        project_id=test_project_limits.id,
+        vuh_max_per_month=10000,
+        vu_max_per_test=10000,
+        vu_browser_max_per_test=1000,
+        duration_max_per_test=3600)
     from_project_id = grafana.k6.get_project_limits_output(project_id=test_project_limits.id)
     ```
 

--- a/sdk/python/pulumiverse_grafana/oncall/escalation.py
+++ b/sdk/python/pulumiverse_grafana/oncall/escalation.py
@@ -30,6 +30,8 @@ class EscalationArgs:
                  notify_if_time_to: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_on_call_from_schedule: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_to_team_members: Optional[pulumi.Input[_builtins.str]] = None,
+                 num_alerts_in_window: Optional[pulumi.Input[_builtins.int]] = None,
+                 num_minutes_in_window: Optional[pulumi.Input[_builtins.int]] = None,
                  persons_to_notifies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  persons_to_notify_next_each_times: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  severity: Optional[pulumi.Input[_builtins.str]] = None):
@@ -37,7 +39,7 @@ class EscalationArgs:
         The set of arguments for constructing a Escalation resource.
         :param pulumi.Input[_builtins.str] escalation_chain_id: The ID of the escalation chain.
         :param pulumi.Input[_builtins.int] position: The position of the escalation step (starts from 0).
-        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         :param pulumi.Input[_builtins.str] action_to_trigger: The ID of an Action for trigger_webhook type step.
         :param pulumi.Input[_builtins.int] duration: The duration of delay for wait type step. (60-86400) seconds
         :param pulumi.Input[_builtins.str] group_to_notify: The ID of a User Group for notify*user*group type step.
@@ -46,6 +48,8 @@ class EscalationArgs:
         :param pulumi.Input[_builtins.str] notify_if_time_to: The end of the time interval for notify*if*time*from*to type step in UTC (for example 18:00:00Z).
         :param pulumi.Input[_builtins.str] notify_on_call_from_schedule: ID of a Schedule for notify*on*call*from*schedule type step.
         :param pulumi.Input[_builtins.str] notify_to_team_members: The ID of a Team for a notify*team*members type step.
+        :param pulumi.Input[_builtins.int] num_alerts_in_window: Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        :param pulumi.Input[_builtins.int] num_minutes_in_window: Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notifies: The list of ID's of users for notify_persons type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notify_next_each_times: The list of ID's of users for notify*person*next*each*time type step.
         :param pulumi.Input[_builtins.str] severity: The severity of the incident for declare_incident type step.
@@ -69,6 +73,10 @@ class EscalationArgs:
             pulumi.set(__self__, "notify_on_call_from_schedule", notify_on_call_from_schedule)
         if notify_to_team_members is not None:
             pulumi.set(__self__, "notify_to_team_members", notify_to_team_members)
+        if num_alerts_in_window is not None:
+            pulumi.set(__self__, "num_alerts_in_window", num_alerts_in_window)
+        if num_minutes_in_window is not None:
+            pulumi.set(__self__, "num_minutes_in_window", num_minutes_in_window)
         if persons_to_notifies is not None:
             pulumi.set(__self__, "persons_to_notifies", persons_to_notifies)
         if persons_to_notify_next_each_times is not None:
@@ -104,7 +112,7 @@ class EscalationArgs:
     @pulumi.getter
     def type(self) -> pulumi.Input[_builtins.str]:
         """
-        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         return pulumi.get(self, "type")
 
@@ -209,6 +217,30 @@ class EscalationArgs:
         pulumi.set(self, "notify_to_team_members", value)
 
     @_builtins.property
+    @pulumi.getter(name="numAlertsInWindow")
+    def num_alerts_in_window(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_alerts_in_window")
+
+    @num_alerts_in_window.setter
+    def num_alerts_in_window(self, value: Optional[pulumi.Input[_builtins.int]]):
+        pulumi.set(self, "num_alerts_in_window", value)
+
+    @_builtins.property
+    @pulumi.getter(name="numMinutesInWindow")
+    def num_minutes_in_window(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_minutes_in_window")
+
+    @num_minutes_in_window.setter
+    def num_minutes_in_window(self, value: Optional[pulumi.Input[_builtins.int]]):
+        pulumi.set(self, "num_minutes_in_window", value)
+
+    @_builtins.property
     @pulumi.getter(name="personsToNotifies")
     def persons_to_notifies(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
         """
@@ -257,6 +289,8 @@ class _EscalationState:
                  notify_if_time_to: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_on_call_from_schedule: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_to_team_members: Optional[pulumi.Input[_builtins.str]] = None,
+                 num_alerts_in_window: Optional[pulumi.Input[_builtins.int]] = None,
+                 num_minutes_in_window: Optional[pulumi.Input[_builtins.int]] = None,
                  persons_to_notifies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  persons_to_notify_next_each_times: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  position: Optional[pulumi.Input[_builtins.int]] = None,
@@ -273,11 +307,13 @@ class _EscalationState:
         :param pulumi.Input[_builtins.str] notify_if_time_to: The end of the time interval for notify*if*time*from*to type step in UTC (for example 18:00:00Z).
         :param pulumi.Input[_builtins.str] notify_on_call_from_schedule: ID of a Schedule for notify*on*call*from*schedule type step.
         :param pulumi.Input[_builtins.str] notify_to_team_members: The ID of a Team for a notify*team*members type step.
+        :param pulumi.Input[_builtins.int] num_alerts_in_window: Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        :param pulumi.Input[_builtins.int] num_minutes_in_window: Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notifies: The list of ID's of users for notify_persons type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notify_next_each_times: The list of ID's of users for notify*person*next*each*time type step.
         :param pulumi.Input[_builtins.int] position: The position of the escalation step (starts from 0).
         :param pulumi.Input[_builtins.str] severity: The severity of the incident for declare_incident type step.
-        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         if action_to_trigger is not None:
             pulumi.set(__self__, "action_to_trigger", action_to_trigger)
@@ -297,6 +333,10 @@ class _EscalationState:
             pulumi.set(__self__, "notify_on_call_from_schedule", notify_on_call_from_schedule)
         if notify_to_team_members is not None:
             pulumi.set(__self__, "notify_to_team_members", notify_to_team_members)
+        if num_alerts_in_window is not None:
+            pulumi.set(__self__, "num_alerts_in_window", num_alerts_in_window)
+        if num_minutes_in_window is not None:
+            pulumi.set(__self__, "num_minutes_in_window", num_minutes_in_window)
         if persons_to_notifies is not None:
             pulumi.set(__self__, "persons_to_notifies", persons_to_notifies)
         if persons_to_notify_next_each_times is not None:
@@ -417,6 +457,30 @@ class _EscalationState:
         pulumi.set(self, "notify_to_team_members", value)
 
     @_builtins.property
+    @pulumi.getter(name="numAlertsInWindow")
+    def num_alerts_in_window(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_alerts_in_window")
+
+    @num_alerts_in_window.setter
+    def num_alerts_in_window(self, value: Optional[pulumi.Input[_builtins.int]]):
+        pulumi.set(self, "num_alerts_in_window", value)
+
+    @_builtins.property
+    @pulumi.getter(name="numMinutesInWindow")
+    def num_minutes_in_window(self) -> Optional[pulumi.Input[_builtins.int]]:
+        """
+        Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_minutes_in_window")
+
+    @num_minutes_in_window.setter
+    def num_minutes_in_window(self, value: Optional[pulumi.Input[_builtins.int]]):
+        pulumi.set(self, "num_minutes_in_window", value)
+
+    @_builtins.property
     @pulumi.getter(name="personsToNotifies")
     def persons_to_notifies(self) -> Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]]:
         """
@@ -468,7 +532,7 @@ class _EscalationState:
     @pulumi.getter
     def type(self) -> Optional[pulumi.Input[_builtins.str]]:
         """
-        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         return pulumi.get(self, "type")
 
@@ -492,6 +556,8 @@ class Escalation(pulumi.CustomResource):
                  notify_if_time_to: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_on_call_from_schedule: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_to_team_members: Optional[pulumi.Input[_builtins.str]] = None,
+                 num_alerts_in_window: Optional[pulumi.Input[_builtins.int]] = None,
+                 num_minutes_in_window: Optional[pulumi.Input[_builtins.int]] = None,
                  persons_to_notifies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  persons_to_notify_next_each_times: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  position: Optional[pulumi.Input[_builtins.int]] = None,
@@ -519,11 +585,13 @@ class Escalation(pulumi.CustomResource):
         :param pulumi.Input[_builtins.str] notify_if_time_to: The end of the time interval for notify*if*time*from*to type step in UTC (for example 18:00:00Z).
         :param pulumi.Input[_builtins.str] notify_on_call_from_schedule: ID of a Schedule for notify*on*call*from*schedule type step.
         :param pulumi.Input[_builtins.str] notify_to_team_members: The ID of a Team for a notify*team*members type step.
+        :param pulumi.Input[_builtins.int] num_alerts_in_window: Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        :param pulumi.Input[_builtins.int] num_minutes_in_window: Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notifies: The list of ID's of users for notify_persons type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notify_next_each_times: The list of ID's of users for notify*person*next*each*time type step.
         :param pulumi.Input[_builtins.int] position: The position of the escalation step (starts from 0).
         :param pulumi.Input[_builtins.str] severity: The severity of the incident for declare_incident type step.
-        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         ...
     @overload
@@ -565,6 +633,8 @@ class Escalation(pulumi.CustomResource):
                  notify_if_time_to: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_on_call_from_schedule: Optional[pulumi.Input[_builtins.str]] = None,
                  notify_to_team_members: Optional[pulumi.Input[_builtins.str]] = None,
+                 num_alerts_in_window: Optional[pulumi.Input[_builtins.int]] = None,
+                 num_minutes_in_window: Optional[pulumi.Input[_builtins.int]] = None,
                  persons_to_notifies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  persons_to_notify_next_each_times: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
                  position: Optional[pulumi.Input[_builtins.int]] = None,
@@ -590,6 +660,8 @@ class Escalation(pulumi.CustomResource):
             __props__.__dict__["notify_if_time_to"] = notify_if_time_to
             __props__.__dict__["notify_on_call_from_schedule"] = notify_on_call_from_schedule
             __props__.__dict__["notify_to_team_members"] = notify_to_team_members
+            __props__.__dict__["num_alerts_in_window"] = num_alerts_in_window
+            __props__.__dict__["num_minutes_in_window"] = num_minutes_in_window
             __props__.__dict__["persons_to_notifies"] = persons_to_notifies
             __props__.__dict__["persons_to_notify_next_each_times"] = persons_to_notify_next_each_times
             if position is None and not opts.urn:
@@ -618,6 +690,8 @@ class Escalation(pulumi.CustomResource):
             notify_if_time_to: Optional[pulumi.Input[_builtins.str]] = None,
             notify_on_call_from_schedule: Optional[pulumi.Input[_builtins.str]] = None,
             notify_to_team_members: Optional[pulumi.Input[_builtins.str]] = None,
+            num_alerts_in_window: Optional[pulumi.Input[_builtins.int]] = None,
+            num_minutes_in_window: Optional[pulumi.Input[_builtins.int]] = None,
             persons_to_notifies: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
             persons_to_notify_next_each_times: Optional[pulumi.Input[Sequence[pulumi.Input[_builtins.str]]]] = None,
             position: Optional[pulumi.Input[_builtins.int]] = None,
@@ -639,11 +713,13 @@ class Escalation(pulumi.CustomResource):
         :param pulumi.Input[_builtins.str] notify_if_time_to: The end of the time interval for notify*if*time*from*to type step in UTC (for example 18:00:00Z).
         :param pulumi.Input[_builtins.str] notify_on_call_from_schedule: ID of a Schedule for notify*on*call*from*schedule type step.
         :param pulumi.Input[_builtins.str] notify_to_team_members: The ID of a Team for a notify*team*members type step.
+        :param pulumi.Input[_builtins.int] num_alerts_in_window: Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        :param pulumi.Input[_builtins.int] num_minutes_in_window: Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notifies: The list of ID's of users for notify_persons type step.
         :param pulumi.Input[Sequence[pulumi.Input[_builtins.str]]] persons_to_notify_next_each_times: The list of ID's of users for notify*person*next*each*time type step.
         :param pulumi.Input[_builtins.int] position: The position of the escalation step (starts from 0).
         :param pulumi.Input[_builtins.str] severity: The severity of the incident for declare_incident type step.
-        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        :param pulumi.Input[_builtins.str] type: The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         opts = pulumi.ResourceOptions.merge(opts, pulumi.ResourceOptions(id=id))
 
@@ -658,6 +734,8 @@ class Escalation(pulumi.CustomResource):
         __props__.__dict__["notify_if_time_to"] = notify_if_time_to
         __props__.__dict__["notify_on_call_from_schedule"] = notify_on_call_from_schedule
         __props__.__dict__["notify_to_team_members"] = notify_to_team_members
+        __props__.__dict__["num_alerts_in_window"] = num_alerts_in_window
+        __props__.__dict__["num_minutes_in_window"] = num_minutes_in_window
         __props__.__dict__["persons_to_notifies"] = persons_to_notifies
         __props__.__dict__["persons_to_notify_next_each_times"] = persons_to_notify_next_each_times
         __props__.__dict__["position"] = position
@@ -738,6 +816,22 @@ class Escalation(pulumi.CustomResource):
         return pulumi.get(self, "notify_to_team_members")
 
     @_builtins.property
+    @pulumi.getter(name="numAlertsInWindow")
+    def num_alerts_in_window(self) -> pulumi.Output[Optional[_builtins.int]]:
+        """
+        Number of alerts that must occur within the time window to continue escalation for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_alerts_in_window")
+
+    @_builtins.property
+    @pulumi.getter(name="numMinutesInWindow")
+    def num_minutes_in_window(self) -> pulumi.Output[Optional[_builtins.int]]:
+        """
+        Time window in minutes to count alerts for notify*if*num*alerts*in_window type step.
+        """
+        return pulumi.get(self, "num_minutes_in_window")
+
+    @_builtins.property
     @pulumi.getter(name="personsToNotifies")
     def persons_to_notifies(self) -> pulumi.Output[Optional[Sequence[_builtins.str]]]:
         """
@@ -773,7 +867,7 @@ class Escalation(pulumi.CustomResource):
     @pulumi.getter
     def type(self) -> pulumi.Output[_builtins.str]:
         """
-        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, repeat*escalation, notify*team*members, declare*incident
+        The type of escalation policy. Can be wait, notify*persons, notify*person*next*each*time, notify*on*call*from*schedule, trigger*webhook, notify*user*group, resolve, notify*whole*channel, notify*if*time*from*to, notify*if*num*alerts*in*window, repeat*escalation, notify*team*members, declare_incident
         """
         return pulumi.get(self, "type")
 


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --kind=provider --target-bridge-version=latest --target-version=4.12.2 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-grafana from 4.12.1  to 4.12.2.
	Fixes #348
