### PR TITLE
Upgrade terraform-provider-grafana to v4.18.0

### DIFF
--- a/.config/mise.lock
+++ b/.config/mise.lock
@@ -59,7 +59,7 @@ version = "3.11.8"
 backend = "core:python"
 
 [[tools."vfox-pulumi:pulumi/pulumi-aws"]]
-version = "7.11.1"
+version = "7.12.0"
 backend = "vfox-pulumi:pulumi/pulumi-aws"
 
 [[tools."vfox-pulumi:pulumi/pulumi-converter-terraform"]]

--- a/provider/go.mod
+++ b/provider/go.mod
@@ -5,7 +5,7 @@ go 1.25.3
 replace github.com/hashicorp/terraform-plugin-sdk/v2 => github.com/pulumi/terraform-plugin-sdk/v2 v2.0.0-20250923233607-7f1981c8674a
 
 require (
-	github.com/grafana/terraform-provider-grafana/v4 v4.17.0
+	github.com/grafana/terraform-provider-grafana/v4 v4.18.0
 	github.com/pulumi/pulumi-terraform-bridge/v3 v3.116.0
 	github.com/pulumi/pulumi/sdk/v3 v3.190.0
 )

--- a/provider/go.sum
+++ b/provider/go.sum
@@ -2080,8 +2080,8 @@ github.com/grafana/synthetic-monitoring-agent v0.43.1 h1:Qejsuf25yZzdImVLZ6K1f5c
 github.com/grafana/synthetic-monitoring-agent v0.43.1/go.mod h1:HO4es33UF/5b3i4JdUhVcvs9abUXESMjFxnWP8y6KG0=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1 h1:6ZQoQVD0sASxe5OVEk/T/YEOYOuilSA434bX4n3SJLQ=
 github.com/grafana/synthetic-monitoring-api-go-client v0.17.1/go.mod h1:3XfDhlxYkC/Apaug0e0vd4wHx8JZJ4k+v5ybny8ZGfc=
-github.com/grafana/terraform-provider-grafana/v4 v4.17.0 h1:3UOr6iz2ykuuhBU+uXKE/29ZLu08EnPGzmE/qsdNaU8=
-github.com/grafana/terraform-provider-grafana/v4 v4.17.0/go.mod h1:UqVVThHS7wNbcvwrjwck02B1yScoUYkoKPFKObXNKtQ=
+github.com/grafana/terraform-provider-grafana/v4 v4.18.0 h1:YM5NmxsChRC/KiwpIHlS8iTjih/YiaDhvY0Y6QmezcQ=
+github.com/grafana/terraform-provider-grafana/v4 v4.18.0/go.mod h1:UqVVThHS7wNbcvwrjwck02B1yScoUYkoKPFKObXNKtQ=
 github.com/grpc-ecosystem/go-grpc-middleware v1.0.1-0.20190118093823-f849b5445de4/go.mod h1:FiyG127CGDf3tlThmgyCl78X/SZQqEOJBCDaAfeWzPs=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0 h1:QGLs/O40yoNK9vmy4rhUGBVyMf1lISBGtXRpsu/Qu/o=
 github.com/grpc-ecosystem/go-grpc-middleware/providers/prometheus v1.1.0/go.mod h1:hM2alZsMUni80N33RBe6J0e423LB+odMj7d3EMP9l20=


### PR DESCRIPTION
This PR was generated via `$ upgrade-provider pulumiverse/pulumi-grafana --kind=provider --target-bridge-version=latest --target-version=4.18.0 --allow-missing-docs=true`.

---

- Upgrading terraform-provider-grafana from 4.17.0  to 4.18.0.
	Fixes #358
